### PR TITLE
Reorganize overall hierarchy of ontology

### DIFF
--- a/plant/schemata/plant_energy_site.yaml
+++ b/plant/schemata/plant_energy_site.yaml
@@ -1,12 +1,11 @@
 input_format_version: 0
-title: IEA Wind Task 37 Wind Plant Ontology version 0.1
+title: definition of a site
 description: A file used as input or output of a wind plant model (for overall energy
   production estimation)
 required:
   - name
   - boundaries
   - plant_energy_resource
-  - layouts
 
 
 # PROPERTIES
@@ -41,22 +40,6 @@ properties:
         title: Circle
         $ref: "#/definitions/circle"
   #~
-  plant_energy_resource:
-    description: >-
-      TODO
-    $ref: "plant_energy_resource.yaml#"
-  #~
-  layouts:
-    description: Position of wind turbines
-    required:
-      - initial_layout
-    Properties:
-      initial_layout:
-        title: Initial layout
-        $ref: "#/definition/layout"
-        
-        
-  #~
   exclusions:
     title: Exclusions
     description: Definition of any site exclusions
@@ -82,33 +65,16 @@ properties:
         $ref: "#/definitions/circle"
 
   #~
+  plant_energy_resource:
+    description: >-
+      TODO
+    $ref: "plant_energy_resource.yaml#"
+       
+  #~
   bathymetry:
    title: Bathymetry
    description: >-
     TODO
-  
-  #~
-  analyses:
-    title: Analyses
-    description: Specific anlayses that can be included with the site definition
-    type: object
-    properties:
-      #~~
-      net_AEP:
-        title: Net AEP for the plant/site
-        type: number
-      gross_AEP:
-        title: Gross AEP for the plant/site
-        type: number
-      wake_model:
-        title: Wake model
-        description: Wake model used in AEP calculations
-        type: object
-        additionalProperties: true
-        properties:
-          name:
-            title: Wake model name
-            type: string
 
 
 # DEFINITIONS
@@ -149,53 +115,3 @@ definitions:
         description: The radius of a circle
         type: number
         units: m   
-
-  layout:
-    title: Wind turbine layout
-    type: object
-    required:
-      - coordinates
-    properties:
-      coordinates:
-        title: Wind turbine coordinate
-        $ref: "#/definitions/coordinates"
-          
-  coordinate:
-    title: Coordinate
-    description: Point coordinate
-    type: object
-    required:
-      - x
-      - y
-    additionalProperties: false
-    properties:
-      x:
-        title: X coordinate
-        description: West-East coordinate
-        type: number
-        units: m
-      y:
-        title: Y coordinate
-        description: South-North coordinate
-        type: number
-        units: m
-  coordinates:
-    title: Coordinates
-    description: Multi-point coordinates
-    type: object
-    required:
-      - x
-      - y
-    additionalProperties: false
-    properties:
-      x:
-        title: X coordinates
-        description: West-East coordinates
-        type: array
-        units: m
-      y:
-        title: Y coordinates
-        description: South-North coordinates
-        type: array
-        units: m
-        

--- a/plant/schemata/plant_energy_turbine.yaml
+++ b/plant/schemata/plant_energy_turbine.yaml
@@ -18,7 +18,7 @@ properties:
     description: Name of the turbine definition
     type: string
   #~
-  power:
+  power: # Is power a good umbrella term for thrust, rotor diameter, hub height?
     title: Power
     description: Definition of the turbine power characteristics
     type: object

--- a/plant/schemata/wind_energy_system.yaml
+++ b/plant/schemata/wind_energy_system.yaml
@@ -1,0 +1,78 @@
+input_format_version: 0
+title: IEA Wind Task 37 Wind Energy System Ontology version 0.1
+description: A file used as input or output of a wind plant model
+required:
+  - name
+  - site
+  - wind_farm # Or something referring to the built or "designable" wind energy conversion system
+
+
+# PROPERTIES
+properties:
+  #~
+  name:
+    title: Name
+    description: Name of the wind energy system
+    type: string
+  #~
+  site:
+    description: >-
+      TODO
+    $ref: "plant_energy_site.yaml#" # Remove "energy" as it will also influence LCOE (bathymetry) or Rename to sth like wes_site.yaml
+  #~
+  wind_farm: # Or better name for built environment
+    description: >-
+      TODO
+    $ref: "plant_wind_farm.yaml#"
+  #~
+  attributes: # Rename for system behaviour/attributes/response quantities.
+    title: Analyses
+    description: Specific anlayses of the entire wind energy system
+    type: object
+    properties:
+      #~~
+      net_AEP:
+        title: Net AEP for the plant/site
+        type: number
+      gross_AEP:
+        title: Gross AEP for the plant/site
+        type: number
+  analyses:
+    wake_model:
+      title: Wake model
+      description: Wake model used in AEP calculations
+      type: object
+      additionalProperties: true
+      properties:
+        name:
+          title: Wake model name
+          type: string
+  optimisation:
+    design_variables:
+      title: List of design variables
+      description: Design variables of the system
+      type: object
+      properties:
+        name:
+          title: Array of design variables
+        $ref: "wind_farm/properties/layouts"
+    method:
+      title: Optimisation method
+      description: Optimisation method used for layout design
+      type: object
+      properties:
+        name:
+          title: Optimisation method name
+          type: string
+    constraints:
+      title: Optimisation constraints functions
+      description: List of constraint functions
+      type: object
+      properties:
+        name:
+          title: Name of constraint
+          type: string
+    initial_layout:
+      Properties:
+        title: Initial layout
+        $ref: "#/definition/layout"

--- a/plant/schemata/wind_farm.yaml
+++ b/plant/schemata/wind_farm.yaml
@@ -1,0 +1,75 @@
+input_format_version: 0
+title: definition of the wind energy conversion system
+description: A file used to define the built environment (and other non-tangible components like O&M)
+required:
+  - layouts
+  - turbines
+optional:
+  - electrical_substations
+  - electrical_collection_array
+  - foundations
+  - O_&_M
+
+# PROPERTIES
+properties:
+  #~
+  layouts:
+    description: Position of wind turbines
+    Properties:
+      $ref: "#/definition/layout"
+
+  turbines:
+    description: Turbine models installed in the WES.
+    $ref: "plant_energy_turbine.yaml#"
+  #~
+
+definitions:
+  layout:
+    title: Wind turbine layout
+    type: object
+    required:
+      - coordinates
+    properties:
+      coordinates:
+        title: Wind turbine coordinate
+        $ref: "#/definitions/coordinates"
+          
+  coordinate:
+    title: Coordinate
+    description: Point coordinate
+    type: object
+    required:
+      - x
+      - y
+    additionalProperties: false
+    properties:
+      x:
+        title: X coordinate
+        description: West-East coordinate
+        type: number
+        units: m
+      y:
+        title: Y coordinate
+        description: South-North coordinate
+        type: number
+        units: m
+  coordinates:
+    title: Coordinates
+    description: Multi-point coordinates
+    type: object
+    required:
+      - x
+      - y
+    additionalProperties: false
+    properties:
+      x:
+        title: X coordinates
+        description: West-East coordinates
+        type: array
+        units: m
+      y:
+        title: Y coordinates
+        description: South-North coordinates
+        type: array
+        units: m
+        


### PR DESCRIPTION
Authored by @sebasanper , this is a re-working of the overall hierarchy of the plant/site ontology. It gives an upper level division between the wind plant and the wind site, and organizes subsequent schemas below that.